### PR TITLE
Refactor layout and add forge-ui support

### DIFF
--- a/javascript/cleaner.js
+++ b/javascript/cleaner.js
@@ -187,6 +187,7 @@
             const tabIndex = getCleanerTabIndex();
 
             gradioApp().querySelector('#tabs').querySelectorAll('button')[tabIndex - 1].click();
+            gradioApp().getElementById('mode_cleanup').querySelectorAll('button')[0].click();
 
             if (cleanupMaskTag) {
                 let buttons = gradioApp().querySelectorAll(`#tab_cleaner_tab button`);
@@ -219,7 +220,7 @@
                     .then(blob => {
                         let container = gradioApp().querySelector("#cleanup_img2maskimg");
 
-                        const imageElems = container.querySelectorAll('div[data-testid="image"]')
+                        const imageElems = container.querySelectorAll('div[data-testid="image"], .forge-container');
 
                         if (imageElems) {
                             const dt = new DataTransfer();
@@ -301,3 +302,8 @@
         }
     });
 })();
+
+function switch_to_cleaner() {
+    gradioApp().querySelector('#tabs').querySelector('#tab_cleaner_tab').querySelectorAll('button')[0].click()
+    gradioApp().getElementById('mode_cleanup').querySelectorAll('button')[0].click();
+}

--- a/scripts/clean_up_tab.py
+++ b/scripts/clean_up_tab.py
@@ -18,97 +18,81 @@ def on_ui_settings():
 
 def send_to_cleaner(result):
     image = Image.open(result[0]["name"])
-
-    print(image)
-
     return image
 
 def on_ui_tabs():
-    
-
-        
     with gr.Blocks() as object_cleaner_tab:
+        is_forge_ui = False
+        tab_index = gr.State(value=0)
+        with ResizeHandleRow(equal_height=False, variant='compact'):
+            with gr.Column(variant='compact'):
+                with gr.Tabs(elem_id="mode_cleanup"):
+                    with gr.TabItem('Clean up', id="clean_up", elem_id="clean_up_tab") as tab_clean_up:
+                        try:
+                            from modules_forge.forge_canvas.canvas import ForgeCanvas
+                            init_img_with_mask = ForgeCanvas(elem_id="cleanup_img2maskimg", height=512, scribble_color=opts.img2img_inpaint_mask_brush_color, scribble_alpha=70)
+                            is_forge_ui = True
+                        except ModuleNotFoundError:
+                            init_img_with_mask = gr.Image(label="Image for clean up with mask", show_label=False, elem_id="cleanup_img2maskimg", source="upload",
+                                                  interactive=True, type="pil", tool="sketch", image_mode="RGBA", height=512, brush_color=opts.img2img_inpaint_mask_brush_color)
+                    with gr.TabItem('Clean up upload', id="clean_up_upload", elem_id="clean_up_upload_tab") as tab_clean_up_upload:
+                        with gr.Column(elem_id=f"cleanup_image_mask"):
+                            clean_up_init_img = gr.Image(label="Image for cleanup", show_label=False, source="upload",
+                                                     interactive=True, type="pil", elem_id="cleanup_img_inpaint_base", height=256)
+                            clean_up_init_mask = gr.Image(
+                                label="Mask", source="upload", interactive=True, type="pil", image_mode="RGBA", elem_id="cleanup_img_inpaint_mask", height=256)
+            with gr.Column():
+                clean_button = gr.Button("Generate", variant="primary")
+                result_gallery = gr.Gallery(label='Output', show_label=False, elem_id=f"cleanup_gallery", columns=4, preview=True, height=opts.gallery_height or None, interactive=False, type="pil", object_fit="contain")
 
-        for tab_name in ["Clean up", "Clean up upload"]:
+                with gr.Row(elem_id=f"image_buttons", elem_classes="image-buttons"):
 
-            with gr.Tab(tab_name) as clean_up_tab, ResizeHandleRow(equal_height=False):
+                    buttons = {
+                        'img2img': ToolButton('🖼️', elem_id=f'_send_to_img2img', tooltip="Send image and generation parameters to img2img tab."),
+                        'inpaint': ToolButton('🎨️', elem_id=f'_send_to_inpaint', tooltip="Send image and generation parameters to img2img inpaint tab."),
+                        'extras': ToolButton('📐', elem_id=f'_send_to_extras', tooltip="Send image and generation parameters to extras tab."),
+                        'cleaner': ToolButton('🧹', elem_id=f'_send_to_cleaner', tooltip="Send image and generation parameters to cleaner tab.")
+                    }
+                    if is_forge_ui:
+                        parameters_copypaste.add_paste_fields("cleaner", init_img_with_mask.background, None)
+                    else:
+                        parameters_copypaste.add_paste_fields("cleaner", init_img_with_mask, None)
+                    for paste_tabname, paste_button in buttons.items():
+                        parameters_copypaste.register_paste_params_button(parameters_copypaste.ParamBinding(
+                            paste_button=paste_button, tabname=paste_tabname, source_tabname=None, source_image_component=result_gallery,
+                            paste_field_names=[]
+                        ))
+        tab_clean_up.select(fn=lambda: 0, inputs=[], outputs=[tab_index])
+        tab_clean_up_upload.select(fn=lambda: 1, inputs=[], outputs=[tab_index])
 
-                init_img_with_mask = None
-                clean_up_init_img = None
-                clean_up_init_mask = None
+        if is_forge_ui:
+            clean_button_click_inputs = [
+                tab_index,
+                init_img_with_mask.background,
+                init_img_with_mask.foreground,
+                clean_up_init_img,
+                clean_up_init_mask,
+            ]
+            click_fn = lama.clean_object_button_click_forge
+        else:
+            clean_button_click_inputs = [
+                tab_index,
+                init_img_with_mask,
+                clean_up_init_img,
+                clean_up_init_mask,
+            ]
+            click_fn = lama.clean_object_button_click
 
-                if tab_name == "Clean up":
-                    init_img_with_mask = gr.Image(label="Image for clean up with mask", show_label=False, elem_id="cleanup_img2maskimg", source="upload",
-                                                  interactive=True, type="pil", tool="sketch", image_mode="RGBA", height=650, brush_color=opts.img2img_inpaint_mask_brush_color)
-                else:
-                    with gr.Column(elem_id=f"cleanup_image_mask"):
-                        clean_up_init_img = gr.Image(label="Image for cleanup", show_label=False, source="upload",
-                                                     interactive=True, type="pil", elem_id="cleanup_img_inpaint_base", height=325)
-                        clean_up_init_mask = gr.Image(
-                            label="Mask", source="upload", interactive=True, type="pil", image_mode="RGBA", elem_id="cleanup_img_inpaint_mask", height=325)
-
-                with gr.Row():
-
-                    with gr.Column(elem_id=f"cleanup_gallery_container"):
-
-                        clean_button = gr.Button("Clean Up", height=100)
-                        result_gallery = gr.Gallery(
-                            label='Output', show_label=False, elem_id=f"cleanup_gallery", preview=True, height=512)
-
-                        with gr.Row(elem_id=f"image_buttons", elem_classes="image-buttons"):
-
-                            buttons = {
-                                'img2img': ToolButton('🖼️', elem_id=f'_send_to_img2img', tooltip="Send image and generation parameters to img2img tab."),
-                                'inpaint': ToolButton('🎨️', elem_id=f'_send_to_inpaint', tooltip="Send image and generation parameters to img2img inpaint tab."),
-                                'extras': ToolButton('📐', elem_id=f'_send_to_extras', tooltip="Send image and generation parameters to extras tab.")
-                            }
-
-                            for paste_tabname, paste_button in buttons.items():
-                                parameters_copypaste.register_paste_params_button(parameters_copypaste.ParamBinding(
-                                    paste_button=paste_button, tabname=paste_tabname, source_tabname=None, source_image_component=result_gallery,
-                                    paste_field_names=[]
-                                ))
-
-                        send_to_cleaner_button = gr.Button("Send back To clean up", height=100)
-
-
-                        if tab_name == "Clean up":
-                            clean_button.click(
-                                fn=lama.clean_object_init_img_with_mask,
-                                inputs=[init_img_with_mask],
-                                outputs=[
-                                    result_gallery
-                                ],
-                            )
-
-                            send_to_cleaner_button.click(
-                                fn=send_to_cleaner,
-                                inputs=[result_gallery],
-                                outputs=[
-                                    init_img_with_mask
-                                ]
-                            )
-                        else:
-
-                            clean_button.click(
-                                fn=lama.clean_object,
-                                inputs=[clean_up_init_img, clean_up_init_mask],
-                                outputs=[
-                                    result_gallery
-                                ],
-                            )
-
-                            send_to_cleaner_button.click(
-                                fn=send_to_cleaner,
-                                inputs=[result_gallery],
-                                outputs=[
-                                    clean_up_init_img
-                                ]
-                            )
-
+        clean_button.click(
+            fn=click_fn,
+            inputs=clean_button_click_inputs,
+            outputs=[
+                result_gallery
+            ],
+            show_progress=True,
+        )
     return (object_cleaner_tab, "Cleaner", "cleaner_tab"),
-
-
+                                            
 script_callbacks.on_ui_tabs(on_ui_tabs)
 script_callbacks.on_ui_settings(on_ui_settings)
 

--- a/scripts/lama.py
+++ b/scripts/lama.py
@@ -9,13 +9,20 @@ from modules.shared import opts
 EXTENSION_PATH = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 MODEL_PATH = os.path.join(EXTENSION_PATH, "models")
 
+def clean_object_button_click(tab_index, init_img_with_mask, clean_up_init_img, clean_up_init_mask):
+    if tab_index == 0:
+        return clean_object(init_img_with_mask['image'],init_img_with_mask['mask'])
+    else:
+        return clean_object(clean_up_init_img,clean_up_init_mask)
 
-def clean_object_init_img_with_mask(init_img_with_mask):
-    return clean_object(init_img_with_mask['image'],init_img_with_mask['mask'])
 
+def clean_object_button_click_forge(tab_index, init_img, init_mask, clean_up_init_img, clean_up_init_mask):
+    if tab_index == 0:
+        return clean_object(init_img, init_mask)
+    else:
+        return clean_object(clean_up_init_img,clean_up_init_mask)
 
 def clean_object(image,mask):
-    
     Lama = LiteLama2()
     
     init_image = image


### PR DESCRIPTION
The cleanup page doesn't work in [forge-ui](https://github.com/[lllyasviel/stable-diffusion-webui-forge](https://github.com/lllyasviel/stable-diffusion-webui-forge/tree/main)/tree/main) (I cannot draw mask area), so I made this PR to fix it and also I refactored the layout of the page to make it similar to the img2img tab.

- Use **[ForgeCanvas](https://github.com/lllyasviel/stable-diffusion-webui-forge/tree/main/modules_forge/forge_canvas)** to draw mask area when the extension is used in forge-ui
- Automatically switch to **Clean up** tab when a user click the button sending output image to **Cleaner** extension
- Refactor the layout of the page

New layout:
![Screenshot 2024-12-29 083623](https://github.com/user-attachments/assets/7c9461db-9b77-48a7-b6df-91e5ef492a24)

![Screenshot 2024-12-29 083634](https://github.com/user-attachments/assets/593b6f82-a28d-4a1a-9eb2-24da200be2c0)
